### PR TITLE
Fix range slider to include bubble

### DIFF
--- a/materialize.html
+++ b/materialize.html
@@ -295,7 +295,9 @@
 </template>
 
 <template name="afInputRange_materialize">
-  <input type="range" value="{{this.value}}" {{this.atts}}/>
+  <p class="range-field">
+    <input type="range" value="{{this.value}}" {{this.atts}}/>
+  </p>
 </template>
 
 <template name="afInputEmail_materialize">


### PR DESCRIPTION
According to http://materializecss.com/forms.html#range, there should be a <p> tag wrapping the input -- without it, the range picker does not include the bubble.
