### PR TITLE
Textarea atts fix

### DIFF
--- a/inputTypes/textarea/textarea.html
+++ b/inputTypes/textarea/textarea.html
@@ -1,3 +1,3 @@
 <template name="afTextarea_materialize">
-  <textarea {{this.atts}}>{{this.value}}</textarea>
+  <textarea {{atts}}>{{this.value}}</textarea>
 </template>


### PR DESCRIPTION
The textarea template was using {{this.atts}} when it should have been using {{atts}} because it has a template helper.
