### PR TITLE
wrap .col in .row for quickForm submit

### DIFF
--- a/components/quickForm/quickForm.html
+++ b/components/quickForm/quickForm.html
@@ -2,14 +2,16 @@
   {{#autoForm this.qfAutoFormContext}}
     {{> afQuickFields}}
     {{#if qfShouldRenderButton}}
-      <div class="col s12">
-        <button type="submit" {{submitButtonAtts}}>
-          {{#with ../atts.buttonContent}}
-            {{this}}
-          {{else}}
-            Submit
-          {{/with}}
-        </button>
+      <div class="row">
+        <div class="col s12">
+          <button type="submit" {{submitButtonAtts}}>
+            {{#with ../atts.buttonContent}}
+              {{this}}
+            {{else}}
+              Submit
+            {{/with}}
+          </button>
+        </div>
       </div>
     {{/if}}
   {{/autoForm}}


### PR DESCRIPTION
The rendering of `{{> quickForm}}` needs scaffolding to wrap the submit `.col` in a `.row`; the `{{> quickFields}}` that precede are in closed `.row`s
