### PR TITLE
onRendered select radio button that should be selected

### DIFF
--- a/inputTypes/select-radio-inline/select-radio-inline.js
+++ b/inputTypes/select-radio-inline/select-radio-inline.js
@@ -2,3 +2,11 @@ Template.afRadioGroupInline_materialize.helpers({
   dsk:      Utility.helpers.dsk,
   itemAtts: Utility.helpers.itemAttsWithUniqId
 });
+
+Template.afRadioGroupInline_materialize.onRendered(function () {
+    var template = this;
+    if (this.data.value) {
+      var selector = 'input[value="' + this.data.value + '"]';
+      template.$(selector).prop('checked', true);
+    }
+});

--- a/inputTypes/select-radio/select-radio.js
+++ b/inputTypes/select-radio/select-radio.js
@@ -2,3 +2,11 @@ Template.afRadioGroup_materialize.helpers({
   dsk:      Utility.helpers.dsk,
   itemAtts: Utility.helpers.itemAttsWithUniqId
 });
+
+Template.afRadioGroup_materialize.onRendered(function () {
+    var template = this;
+    if (this.data.value) {
+      var selector = 'input[value="' + this.data.value + '"]';
+      template.$(selector).prop('checked', true);
+    }
+});


### PR DESCRIPTION
This is a quick fix (similar to #49), although both of these should probably be moved into: utilities/initialize-select after looking around. I'm looking for quick fixes to release something and will revisit this PR as well.
