### PR TITLE
Handle multiple selects

### DIFF
--- a/components/afFormGroup/afFormGroup.js
+++ b/components/afFormGroup/afFormGroup.js
@@ -46,6 +46,7 @@ Template.afFormGroup_materialize.rendered = function() {
             var placeholder = _this.data.afFieldInputAtts.placeholder;
             var skipActiveLabelTypes = [
                 'select',
+                'select-multiple',
                 'checkbox',
                 'checkbox-group',
                 'boolean-checkbox',

--- a/inputTypes/select-multiple/select-multiple.js
+++ b/inputTypes/select-multiple/select-multiple.js
@@ -1,10 +1,6 @@
 Template.afSelectMultiple_materialize.helpers({
+  atts: Utility.attsToggleInvalidClass,
   optionAtts: Utility.optionAtts
 });
 
-Template.afSelectMultiple_materialize.helpers({
-  atts: function() {
-    var atts = Utility.attsToggleInvalidClass.call(this);
-    return AutoForm.Utility.addClass(atts, 'browser-default');
-  }
-});
+Template.afSelectMultiple_materialize.onRendered(Utility.initializeSelect);

--- a/utilities/option-atts.js
+++ b/utilities/option-atts.js
@@ -1,11 +1,13 @@
 Utility.optionAtts = function() {
-  var atts, item;
-  item = this;
-  atts = {
-    value: item.value
-  };
-  if (item.selected) {
+  var atts = _.pick(this, 'value');
+
+  if (this.selected) {
     atts.selected = '';
   }
+
+  if (!_.isEmpty(this.htmlAtts)) {
+    _.extend(atts, this.htmlAtts);
+  }
+
   return atts;
 };


### PR DESCRIPTION
[Multiple selects are supported by Materialize](http://materializecss.com/forms.html#select):

> You can add the property `multiple` to get the multiple select and select several options.

# Example

This is the generated field:
![Generated field](https://cloud.githubusercontent.com/assets/2417752/14613095/f8216530-059a-11e6-83e6-211a299ec5ae.png)

And you can select several options: 
![capture d ecran de 2016-04-18 19-03-51](https://cloud.githubusercontent.com/assets/2417752/14613094/f82005a0-059a-11e6-87fd-e184b69238fc.png)

I used this schema (and the [`quickForm`](https://github.com/aldeed/meteor-autoform#quickform) component):

``` js
const example = new SimpleSchema({
  sports: {
    type: [String],
    label: 'Sports',
    autoform: {
      defaultValue: ['badminton', 'basketball'],
      options: [
        { label: 'Badminton 2x2', value: 'badminton' },
        { label: 'Basket-ball', value: 'basketball' },
        { label: 'Football 5x5', value: 'football' }
      ]
    }
  }
});
```
