### PR TITLE
Updated material icons - fix for issue #101

### DIFF
--- a/components/afArrayField/afArrayField.html
+++ b/components/afArrayField/afArrayField.html
@@ -10,7 +10,7 @@
           data-autoform-field="{{atts.name}}"
           data-autoform-minCount="{{atts.minCount}}"
           data-autoform-maxCount="{{atts.maxCount}}">
-            Add <i class="mdi-content-add"></i>
+            Add <i class="material-icons">add</i>
         </button>
       {{/if}}
     </div>
@@ -26,7 +26,7 @@
       {{#if afArrayFieldHasMoreThanMinimum name=../atts.name minCount=../atts.minCount maxCount=../atts.maxCount}}
         <div class="collection-item">
           <button type="button" class="btn autoform-remove-item">
-            Remove <span class="mdi-content-clear"></span>
+            Remove <i class="material-icons">clear</i>
           </button>
         </div>
       {{/if}}

--- a/components/afFormGroup/afFormGroup.html
+++ b/components/afFormGroup/afFormGroup.html
@@ -12,7 +12,7 @@
             {{/if}}
             {{#if afFieldIsInvalid name=this.name}}
                 <div class="red-text">
-                    <i class="mdi-alert-warning"></i> {{{afFieldMessage name=this.name}}}
+                    <i class="material-icons">warning</i> {{{afFieldMessage name=this.name}}}
                 </div>
             {{/if}}
         </div>

--- a/components/afFormGroup/afFormGroup.js
+++ b/components/afFormGroup/afFormGroup.js
@@ -46,6 +46,7 @@ Template.afFormGroup_materialize.rendered = function() {
             var placeholder = _this.data.afFieldInputAtts.placeholder;
             var skipActiveLabelTypes = [
                 'select',
+                'select-multiple',
                 'checkbox',
                 'checkbox-group',
                 'boolean-checkbox',

--- a/inputTypes/select-multiple/select-multiple.js
+++ b/inputTypes/select-multiple/select-multiple.js
@@ -1,10 +1,6 @@
 Template.afSelectMultiple_materialize.helpers({
+  atts: Utility.attsToggleInvalidClass,
   optionAtts: Utility.optionAtts
 });
 
-Template.afSelectMultiple_materialize.helpers({
-  atts: function() {
-    var atts = Utility.attsToggleInvalidClass.call(this);
-    return AutoForm.Utility.addClass(atts, 'browser-default');
-  }
-});
+Template.afSelectMultiple_materialize.onRendered(Utility.initializeSelect);

--- a/utilities/option-atts.js
+++ b/utilities/option-atts.js
@@ -1,11 +1,13 @@
 Utility.optionAtts = function() {
-  var atts, item;
-  item = this;
-  atts = {
-    value: item.value
-  };
-  if (item.selected) {
+  var atts = _.pick(this, 'value');
+
+  if(this.selected) {
     atts.selected = '';
   }
+
+  if (!_.isEmpty(this.htmlAtts)) {
+    _.extend(atts, this.htmlAtts);
+  }
+
   return atts;
 };


### PR DESCRIPTION
[Materialize has changed the way icons should be added](http://materializecss.com/icons.html)

Old: `<i class="mdi-content-add"></i>`

> To use these icons, use the material-icons class on an element and provide the ligature as the text content.

New: `<i class="material-icons">add</i>`

You can control the size of the icons via the `font-size` property of the icon.
